### PR TITLE
Dev/workbench mfr

### DIFF
--- a/be-running-scheduler/joi/schedulesSchema.js
+++ b/be-running-scheduler/joi/schedulesSchema.js
@@ -4,7 +4,7 @@ const daySchema = Joi.object({
   _id: Joi.string().optional(),
   date: Joi.date().required(),
   type: Joi.string().optional(),
-  distance: Joi.number().allow("").optional(),
+  distance: Joi.number().allow("").allow(null).optional(),
   // description can be an empty string,
   description: Joi.string().allow("").optional(),
 });

--- a/fe-running-scheduler/src/components/ButtonHiddenInput.jsx
+++ b/fe-running-scheduler/src/components/ButtonHiddenInput.jsx
@@ -1,7 +1,7 @@
 const ButtonHiddenInput = ({ text, accept, onClick, onChange, disabled, refForward }) => {
   return (
     <button
-      className="btn btn-sm ring-1 ring-accent"
+      className="btn btn-xs md:btn-sm min-w-max ring-1 ring-accent"
       onClick={onClick}
       disabled={disabled ? true : false}
     >

--- a/fe-running-scheduler/src/components/ButtonToggle.jsx
+++ b/fe-running-scheduler/src/components/ButtonToggle.jsx
@@ -1,7 +1,7 @@
 const ButtonToggle = ({text, onClick}) => {
   return (
     <label className="label cursor-pointer">
-    <span className="label-text text-base text-nowrap">
+    <span className="label-text text-xs md:text-sm text-nowrap">
       {text}
     </span>
     <input

--- a/fe-running-scheduler/src/components/Calendar/ButtonCalendarNavigate.jsx
+++ b/fe-running-scheduler/src/components/Calendar/ButtonCalendarNavigate.jsx
@@ -5,7 +5,7 @@ const ButtonCalendarNavigate = ({
 }) => {
   return (
     <button
-      className="btn btn-sm"
+      className="btn btn-sm text-xs md:text-sm"
       onClick={onClick}
       disabled={disabled ? true : false}
     >

--- a/fe-running-scheduler/src/components/Calendar/CalendarBar.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CalendarBar.jsx
@@ -48,9 +48,9 @@ const CalendarBar = ({
   };
 
   return (
-    <div className="flex flex-auto flex-wrap navbar sticky top-0 z-10 bg-base-100">
-      <div className="flex flex-1 navbar-start">
-        <div className="">
+    <div className="flex justify-between items-center text-xs md:text-sm sticky top-0 z-10 bg-base-100 mb-2">
+      <div className="flex items-center">
+        <div className="flex">
           <ButtonCalendarNavigate
             text={"Previous"}
             onClick={showPreviousCalendar}
@@ -84,9 +84,9 @@ const CalendarBar = ({
         </div>
       </div>
 
-      <div className="flex flex-1 navbar-center">
-        <div className="flex flex-1  w-1/2 justify-around ">
-          <div className="flex">
+      <div className="">
+        <div className="">
+          <div className="flex items-center">
             {title ? (
               <span
                 onClick={handleCalendarEdit}
@@ -120,8 +120,8 @@ const CalendarBar = ({
           </div>
         </div>
       </div>
-      <div className="flex flex-1 navbar-end">
-        <span className="flex ">
+      <div className="">
+        <span className="flex">
           <ButtonToggle text={"Show Notes"} onClick={toggleNotes} />
           <ButtonToggle text={"Hide Schedule"} onClick={toggleSchedule} />
         </span>

--- a/fe-running-scheduler/src/components/Calendar/CalendarBody.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CalendarBody.jsx
@@ -2,10 +2,12 @@ import WeekDaysBar from "./WeekDaysBar";
 import CalendarWeekRow from "./CalendarWeekRow";
 
 const CalendarBody = ({ schedule, runs, notes, hideSchedule }) => {
-
   return (
-    <div className="grid md:grid-cols-8 grid-cols-8 mx-4 gap-x-4 gap-y-1">
+    <div className="grid grid-cols-8 gap-2">
       <WeekDaysBar />
+      <div className="text-center">Summary</div>
+      <div className="col-span-8 border border-base-300"></div>
+
       {schedule
         ? Object.entries(schedule.weeks).map(([weekNumber, data]) => {
             return (

--- a/fe-running-scheduler/src/components/Calendar/CalendarWeekRow.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CalendarWeekRow.jsx
@@ -19,9 +19,55 @@ const CalendarWeekRow = ({
     navigate(`schedule/${weekNumber}/${day}/${id}`);
   };
 
+  const runDataByDay = (day) => {
+    return runningDataWeek.days[day];
+  };
+
   return (
     <>
-      {!hideSchedule &&
+      {Object.entries(scheduleDataWeek.days).map(([day, data]) => {
+        return (
+          <div key={day} className="flex flex-col justify-between">
+            {!hideSchedule && (
+              <>
+                <TrainingCard
+                  key={data._id}
+                  data={data}
+                  openTrainingCard={() =>
+                    openTrainingCard(data._id, weekNumber, day)
+                  }
+                />
+                <div
+                  key={`${weekNumber}, daySpacer`}
+                  className="border-y-4 border-base-200"
+                ></div>
+              </>
+            )}
+            <RunCard
+              key={runDataByDay(day)._id}
+              data={runDataByDay(day)}
+              openRunCard={() =>
+                openRunCard(runDataByDay(day)._id, weekNumber, day)
+              }
+              notes={notes}
+              hideSchedule={hideSchedule}
+            />
+          </div>
+        );
+      })}
+      <div>
+        <SummaryCard
+          scheduleWeek={scheduleDataWeek}
+          runningWeek={runningDataWeek}
+          weekNumber={weekNumber}
+          hideSchedule={hideSchedule}
+        />
+      </div>
+      <div
+        key={`${weekNumber}, weekSpacer`}
+        className="col-span-8 border border-base-300"
+      ></div>
+      {/* {!hideSchedule &&
         Object.entries(scheduleDataWeek.days).map(([day, data]) => {
           return (
             <TrainingCard
@@ -57,9 +103,7 @@ const CalendarWeekRow = ({
           weekNumber={weekNumber}
           hideSchedule={hideSchedule}
         />
-      )}
-
-      <div className="col-span-8 border-y-8 border-base-300"></div>
+      )} */}
     </>
   );
 };

--- a/fe-running-scheduler/src/components/Calendar/CardBody.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CardBody.jsx
@@ -1,12 +1,14 @@
 const CardBody = ({ children, formattedDate, hideSchedule }) => (
-    <div className="card-body justify-start gap-1 overflow-clip relative">
-      {hideSchedule && formattedDate && (
-        <div className="absolute top-0 right-0 text-white text-xs mt-1 mr-2">
-          {formattedDate}
-        </div>
-      )}
+  <div className="flex flex-col justify-start text-xs">
+    {hideSchedule && formattedDate && (
+      <div className="absolute top-0 right-0 text-white text-xs mr-0.5">
+        {formattedDate}
+      </div>
+    )}
+    <div className="mx-2 mt-3 mb-1 flex flex-col gap-0 justify-start text-xs">
       {children}
     </div>
-  );
+  </div>
+);
 
 export default CardBody;

--- a/fe-running-scheduler/src/components/Calendar/CardContainer.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CardContainer.jsx
@@ -1,7 +1,10 @@
 const CardContainer = ({ isToday, openRunCard, children }) => {
+  // const baseClass =
+  //   "mx-0.5 max-w-44 min-w-20 card card-compact rounded-tr-none rounded-br-none rounded-tl-none " +
+  //   "bg-gray-900 ring-1 hover:ring-2 cursor-pointer";
   const baseClass =
-    "max-w-44 min-w-20 card card-compact rounded-tr-none rounded-br-none rounded-tl-none " +
-    "bg-gray-900 ring-2 hover:ring-4 cursor-pointer";
+  "mx-0.5 max-w-44 min-w-20 card card-compact rounded-tr-none rounded-br-none rounded-tl-none " +
+  "bg-gray-900 ring-1 hover:ring-2 cursor-pointer h-full overflow-clip";
   const todayClass = isToday ? "ring-green-500" : "";
 
   return (

--- a/fe-running-scheduler/src/components/Calendar/CardDetails.jsx
+++ b/fe-running-scheduler/src/components/Calendar/CardDetails.jsx
@@ -5,47 +5,48 @@ import {
 import { Icons } from "@/components";
 
 const CardDetails = ({ data, hideSchedule }) => {
-  const { distance, duration, tempo, avg_hr, effort, comments } =
-    data;
+  const { distance, duration, tempo, avg_hr, effort, comments } = data;
 
   const baseCommentsClass = "text-wrap mt-0";
   const hideScheduleClass = hideSchedule ? "line-clamp-6" : "line-clamp-2";
 
   return (
-    <div className="flex flex-col gap-1 justify-start text-xs">
-      <div className="flex flex-wrap text-nowrap gap-1">
-        {distance && (
-          <p className="flex items-center gap-x-1">
-            <Icons type="distance" />
-            {parseFloat(distance).toFixed(1)} km
-          </p>
-        )}
-        {duration && (
-          <p className="flex items-center gap-x-1">
-            <Icons type="time" />
-            {getSecondsAsHoursMinutesSecondsString(duration)}
-          </p>
-        )}
-        {tempo && (
-          <p className="flex items-center gap-x-1">
-            <Icons type="speed" />
-            <span>{getTempoAsMinutesSecondsString(tempo)} /km</span>
-          </p>
-        )}
-        {avg_hr && (
-          <p className="flex items-center gap-x-1">
-            <Icons type="heartRate" />
-            {avg_hr}
-          </p>
-        )}
-        {effort && (
-          <p className="flex items-center gap-x-1">
-            <Icons type="effort" />
-            {effort}/10
-          </p>
-        )}
-        {comments && <span className={`${baseCommentsClass} ${hideScheduleClass}`}>{comments}</span>}
-      </div>
+    <div className="flex flex-wrap text-nowrap gap-1">
+      {distance && (
+        <p className="flex items-center gap-x-1">
+          <Icons type="distance" />
+          {parseFloat(distance).toFixed(1)} km
+        </p>
+      )}
+      {duration && (
+        <p className="flex items-center gap-x-1">
+          <Icons type="time" />
+          {getSecondsAsHoursMinutesSecondsString(duration)}
+        </p>
+      )}
+      {tempo && (
+        <p className="flex items-center gap-x-1">
+          <Icons type="speed" />
+          <span>{getTempoAsMinutesSecondsString(tempo)}/km</span>
+        </p>
+      )}
+      {avg_hr && (
+        <p className="flex items-center gap-x-1">
+          <Icons type="heartRate" />
+          {avg_hr}
+        </p>
+      )}
+      {effort && (
+        <p className="flex items-center gap-x-1">
+          <Icons type="effort" />
+          {effort}/10
+        </p>
+      )}
+      {comments && (
+        <span className={`${baseCommentsClass} ${hideScheduleClass}`}>
+          {comments}
+        </span>
+      )}
     </div>
   );
 };

--- a/fe-running-scheduler/src/components/Calendar/RunCard.jsx
+++ b/fe-running-scheduler/src/components/Calendar/RunCard.jsx
@@ -13,12 +13,15 @@ const RunCard = ({ data, openRunCard, notes, hideSchedule }) => {
     day: "numeric",
   }).format(Date.parse(date));
 
+  // If there is no name, then there is also no data of a run to display
+  if (!name) return null;
+
   return (
     <CardContainer isToday={isToday} openRunCard={openRunCard}>
       <CardBody formattedDate={formattedDate} hideSchedule={hideSchedule}>
         <div
-          className={`card-title text-nowrap overflow-clip text-sm ${
-            hideSchedule ? "mt-2" : "-mt-3"
+          className={`card-title text-xs md:text-sm ${
+            hideSchedule ? "mt-1" : "-mt-2"
           }`}
         >
           {name}

--- a/fe-running-scheduler/src/components/Calendar/SummaryCard.jsx
+++ b/fe-running-scheduler/src/components/Calendar/SummaryCard.jsx
@@ -18,47 +18,52 @@ const SummaryCard = ({
     avgPace = null,
   } = calculateWeeklySummary(scheduleWeek, runningWeek);
 
-  const cardClasses = `card card-compact min-w-28 max-w-44 bg-gray-950 ring-1 ring-accent rounded-tr-none rounded-br-none 
-                      ${hideSchedule ? "row-span-1" : "row-span-2"} 
-                      h-full hover:ring-2 cursor-pointer`;
+  // const cardClasses = `card card-compact mt-0.5 mr-0.5 min-w-28 max-w-44 bg-gray-950 ring-1 ring-accent rounded-tr-none rounded-br-none
+  //                     ${hideSchedule ? "row-span-1" : "row-span-2"}
+  //                     h-full`;
+  const cardClasses = `card card-compact mt-0.5 mr-0.5 max-w-44 bg-gray-950 ring-1 ring-accent rounded-tr-none rounded-br-none h-full`;
 
-  // Helper function to safely display values or fallback
+  // Helper function to display values or fallback
   const renderValue = (value, suffix = "") =>
     value ? `${value}${suffix}` : "-";
 
   return (
     <div className={cardClasses}>
-      <div className="card-body text-nowrap overflow-clip">
-        <h2 className="card-title -mt-1 text-sm">{weekTitle}</h2>
-        <div className="divide-y-4 divide-cyan-500 -mt-1">
-          <p className="flex items-center gap-x-1 mb-1">
-            <Icons type="goal" />
-            {renderValue(totalDistancePlanned, " km")}
-          </p>
-          <p></p>
-        </div>
+      {/* <div className="card-body text-nowrap overflow-clip"> */}
+      <div className="flex flex-col justify-start overflow-clip">
+        <div className="mx-2 mt-3 mb-1 flex flex-col gap-0 justify-start text-xs">
+          <h2 className="card-title -mt-1 text-xs md:text-sm">{weekTitle}</h2>
+          <div className="divide-y-4 divide-cyan-500">
+            <p className="flex items-center gap-x-1 mb-2">
+              <Icons type="goal" />
+              {renderValue(totalDistancePlanned, " km")}
+            </p>
+            <p></p>
+          </div>
 
-        <div className="flex flex-col pt-4 space-y-2 ">
-          <p className="flex items-center gap-x-1">
-            <Icons type="distance" />
-            {renderValue(Math.round(totalDistanceRun), " km")}
-          </p>
-          <p className="flex items-center gap-x-1">
-            <Icons type="time" />
-            {renderValue(totalTimeFormatted)}
-          </p>
-          <p className="flex items-center gap-x-1">
-            <Icons type="speed" />
-            {renderValue(getTempoAsMinutesSecondsString(avgPace), " /km")}
-          </p>
-          <p className="flex items-center gap-x-1">
-            <Icons type="heartRate" />
-            {renderValue(Math.round(avg_hr))}
-          </p>
-          <p className="flex items-center gap-x-1">
-            <Icons type="effort" />
-            {renderValue(Math.round(avgEffort), "/10")}
-          </p>
+          {/* <div className="flex flex-col pt-4 space-y-2 "> */}
+          <div className="flex flex-col justify text-nowrap gap-1 pt-4">
+            <p className="flex items-center gap-x-1">
+              <Icons type="distance" />
+              {renderValue(Math.round(totalDistanceRun), " km")}
+            </p>
+            <p className="flex items-center gap-x-1">
+              <Icons type="time" />
+              {renderValue(totalTimeFormatted)}
+            </p>
+            <p className="flex items-center gap-x-1">
+              <Icons type="speed" />
+              {renderValue(getTempoAsMinutesSecondsString(avgPace), "/km")}
+            </p>
+            <p className="flex items-center gap-x-1">
+              <Icons type="heartRate" />
+              {renderValue(Math.round(avg_hr))}
+            </p>
+            <p className="flex items-center gap-x-1">
+              <Icons type="effort" />
+              {renderValue(Math.round(avgEffort), "/10")}
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/fe-running-scheduler/src/components/Calendar/TrainingCard.jsx
+++ b/fe-running-scheduler/src/components/Calendar/TrainingCard.jsx
@@ -12,17 +12,19 @@ const TrainingCard = ({ data, openTrainingCard }) => {
 
   const formattedDate = formatDate(date, { month: "numeric", day: "numeric" });
 
-  const cardClasses = `card card-compact bg-gray-800 max-w-44 min-w-20 rounded-br-none rounded-bl-none rounded-tr-none ring-2 hover:ring-4 cursor-pointer 
-  ${isToday && "ring-green-500"}`;
-
+  const isRestDay = type === "Rest Day";
+  // const cardClasses = `card card-compact mx-0.5 mt-0.5 bg-gray-800 max-w-44 min-w-20 rounded-br-none rounded-bl-none rounded-tr-none ring-1 hover:ring-2 cursor-pointer 
+  // ${isToday && "ring-green-500"}`;
+  const cardClasses = `card card-compact mx-0.5 mt-0.5 bg-gray-800 max-w-44 min-w-20 rounded-br-none rounded-bl-none rounded-tr-none ring-1 hover:ring-2 cursor-pointer ${!isRestDay && "h-full"} overflow-clip  ${isToday && "ring-green-500"}`;
+  
   return (
     <div className={cardClasses} onClick={openTrainingCard}>
-      <div className="card-body justify-start gap-0 overflow-clip relative">
-        <div className="absolute top-0 right-0 text-white text-xs mt-1 mr-2">
+      <div className="flex flex-col justify-start overflow-clip">
+        <div className="absolute top-0 right-0.5 text-white text-xs">
           {formattedDate}
         </div>
-        <div className="flex flex-col gap-1 justify-start text-xs">
-          {type && <div className="card-title text-sm mt-1">{type}</div>}
+        <div className="mx-2 mt-3 mb-1 flex flex-col gap-0 justify-start text-xs">
+          {type && <div className="card-title text-xs md:text-sm mt-1">{type}</div>}
           <div className="flex flex-wrap text-nowrap gap-1">
             {distance && (
               <p className="flex items-center gap-x-1">
@@ -31,7 +33,7 @@ const TrainingCard = ({ data, openTrainingCard }) => {
               </p>
             )}
             {description && (
-              <p className="flex items-start mt-0 text-wrap gap-x-1">
+              <p className="flex items-start text-wrap gap-x-1">
                 <Icons type="note" />
                 <span className="line-clamp-3"> {description}</span>
               </p>

--- a/fe-running-scheduler/src/components/Calendar/WeekDaysBar.jsx
+++ b/fe-running-scheduler/src/components/Calendar/WeekDaysBar.jsx
@@ -2,7 +2,7 @@ const WeekDaysBar = () => {
   const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
   const weekDaysBar = daysOfWeek.map((day) => (
-    <div key={day} className="text-left">
+    <div key={day} className="text-left text-xs md:text-sm ml-3">
       {day}
     </div>
   ));
@@ -10,8 +10,6 @@ const WeekDaysBar = () => {
   return (
     <>
       {weekDaysBar}
-      <div className="text-center">Summary</div>
-      <div className="col-span-8 border border-base-300"></div>
     </>
   );
 };

--- a/fe-running-scheduler/src/components/NavBar/NavBar.jsx
+++ b/fe-running-scheduler/src/components/NavBar/NavBar.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "@/context";
 import { useFetchUserProfile } from "@/lib/hooks/miscDataHooks";
 import { arrayBufferToBase64 } from "@/utils/arrayBufferToBase64";
@@ -31,9 +31,9 @@ const NavBar = () => {
     : "/profilePlaceHolder.webp";
 
   return (
-    <div className="navbar w-full z-50 min-w-min">
+    <div className="navbar z-50">
       <div className="navbar-start">
-        <a className="btn btn-ghost text-xl">{appName}</a>
+        <Link to="calendar" className="btn btn-ghost text-base md:text-lg">{appName}</Link>
       </div>
       <div className="navbar-center">
         <NavBarNavButtons />

--- a/fe-running-scheduler/src/components/NavBar/NavBarDropDownMenu.jsx
+++ b/fe-running-scheduler/src/components/NavBar/NavBarDropDownMenu.jsx
@@ -16,7 +16,7 @@ const NavBarDropDownMenu = ({imageUrl, user, openProfileModal, openEquipmentModa
     </div>
     <ul
       tabIndex={0}
-      className="menu menu-md dropdown-content bg-base-300 rounded-box z-[50] mt-3 w-52 p-2 shadow"
+      className="menu menu-sm md:menu-md dropdown-content bg-base-300 rounded-box z-[50] mt-3 w-52 p-2 shadow"
     >
       <li>
         <h2 className="text-lg font-bold">{user?.userName}</h2>

--- a/fe-running-scheduler/src/components/NavBar/NavBarNavButtons.jsx
+++ b/fe-running-scheduler/src/components/NavBar/NavBarNavButtons.jsx
@@ -3,10 +3,10 @@ import { NavLink } from "react-router-dom";
 const NavBarNavButtons = () => {
   return (
     <>
-      <NavLink to="overview" className="btn btn-ghost text-l">
+      <NavLink to="overview" className="btn btn-xs md:btn-sm btn-ghost text-l">
         Overview
       </NavLink>
-      <NavLink to="calendar" className="btn btn-ghost text-l">
+      <NavLink to="calendar" className="btn btn-xs md:btn-sm btn-ghost text-l">
         Calendar
       </NavLink>
     </>

--- a/fe-running-scheduler/src/components/RunAndTrainingDetails/TypeSelectOptions.jsx
+++ b/fe-running-scheduler/src/components/RunAndTrainingDetails/TypeSelectOptions.jsx
@@ -16,7 +16,7 @@ const TypeSelectOptions = ({ type, handleChange }) => {
         <option value="Workout Day">Workout Day</option>
         <option value="Interval Workout">Interval Workout</option>
         <option value="Steady State">Steady State</option>
-        <option value="Threshold/Tempo Run">Threshold/Tempo Run</option>
+        <option value="Threshold / Tempo Run">Threshold / Tempo Run</option>
         <option value="Progression Run">Progression Run</option>
         <option value="Hill Sprints">Hill Sprints</option>
         <option value="Strides">Strides</option>

--- a/fe-running-scheduler/src/index.css
+++ b/fe-running-scheduler/src/index.css
@@ -18,7 +18,7 @@
     text-decoration-thickness: 3px;
   }
 
-  @media (max-width: 300px) {
+  /* @media (max-width: 300px) {
     .zoomable {
       zoom: 0.4; 
   }
@@ -42,4 +42,4 @@
     .zoomable {
       zoom: 1; 
     }
-  }
+  } */

--- a/fe-running-scheduler/src/layouts/AuthLayout.jsx
+++ b/fe-running-scheduler/src/layouts/AuthLayout.jsx
@@ -1,23 +1,12 @@
 import { useAuth } from "@/context";
 import { Outlet, Navigate } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
 
 const AuthLayout = () => {
   const { auth } = useAuth();
 
   // console.log("AuthLayout.jsx");
 
-  return (
-    <div className="container mx-auto zoomable">
-      <ToastContainer
-        position="bottom-right"
-        autoClose={2500}
-        theme="colored"
-      />
-      {auth ? <Outlet /> : <Navigate to="/login" />}
-
-    </div>
-  );
+  return <>{auth ? <Outlet /> : <Navigate to="/login" />}</>;
 };
 
 export default AuthLayout;

--- a/fe-running-scheduler/src/layouts/AuthLayout.jsx
+++ b/fe-running-scheduler/src/layouts/AuthLayout.jsx
@@ -11,7 +11,7 @@ const AuthLayout = () => {
     <div className="container mx-auto zoomable">
       <ToastContainer
         position="bottom-right"
-        autoClose={1500}
+        autoClose={2500}
         theme="colored"
       />
       {auth ? <Outlet /> : <Navigate to="/login" />}

--- a/fe-running-scheduler/src/layouts/RootLayout.jsx
+++ b/fe-running-scheduler/src/layouts/RootLayout.jsx
@@ -4,13 +4,14 @@ import { useNavigate, useLocation, useNavigation } from "react-router-dom";
 import "react-toastify/dist/ReactToastify.css";
 import { Loading, Footer } from "@/components";
 import { useGetCalendarOrder } from "../lib/hooks/useGetCalendarOrder";
+import { ToastContainer } from "react-toastify";
 
 const RootLayout = () => {
-  // console.log("RootLayout");  
+  // console.log("RootLayout");
   const navigation = useNavigation();
   const isLoading = navigation.state === "loading";
   // console.log(navigation.state);
-  
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -26,7 +27,12 @@ const RootLayout = () => {
     navigate(`calendar/${currentCalendarId}`);
 
   return (
-    <div className="flex flex-col min-h-screen min-w-fit">
+    <div className="container flex flex-col min-h-screen zoomable mx-4 md:mx-auto">
+      <ToastContainer
+        position="bottom-right"
+        autoClose={2500}
+        theme="colored"
+      />
       <NavBar />
       {isLoading ? (
         <Loading />

--- a/fe-running-scheduler/src/pages/CalendarView.jsx
+++ b/fe-running-scheduler/src/pages/CalendarView.jsx
@@ -28,7 +28,7 @@ const CalendarView = () => {
   const isCalendarListEmpty = cyclingProps.calendarSize === 0;
 
   return (
-    <div className="min-w-min flex-grow">
+    <div className="flex-grow min-w-[680px]">
       <>
         <CalendarBar
           title={runs?.meta?.title}

--- a/fe-running-scheduler/src/pages/Login.jsx
+++ b/fe-running-scheduler/src/pages/Login.jsx
@@ -26,7 +26,12 @@ const Login = () => {
       toast.success(`Successfully logged in!`);
       navigate("/auth");
     } catch (error) {
-      toast.error(error.message);
+      console.log(error);
+      if (error.message === "Failed to fetch") {
+        toast.error("Server is down. Please try again later.");
+      } else {
+        toast.error(error.message);
+      }
     } finally {
       setLoading(false);
     }

--- a/fe-running-scheduler/src/pages/Welcome.jsx
+++ b/fe-running-scheduler/src/pages/Welcome.jsx
@@ -1,22 +1,16 @@
 // WelcomePage.jsx
-import { Link, Outlet, useNavigation, Navigate } from "react-router-dom";
-// import LoadingOverlay from "react-loading-overlay-ts";
-import { Loading, Footer, StartupDelay } from "@/components";
+import { Link, Outlet, Navigate } from "react-router-dom";
+import { Footer, StartupDelay } from "@/components";
 import { useAuth } from "@/context";
+import { ToastContainer } from "react-toastify";
 
 const WelcomePage = () => {
   const { auth } = useAuth();
-  const navigation = useNavigation();
 
   if (auth) return <Navigate to={location.state?.next || "/auth"} />;
 
   return (
-    <>
-      {navigation.state === "loading" && <Loading />}
-      {/* <div className="flex justify-center text-nowrap h-full w-full mt-14">
-          <LoadingOverlay active={true} spinner text="Loading..." />
-        </div>
-      )} */}
+    <div className="container mx-auto">
       <div className="flex flex-col items-center justify-center min-h-screen bg-base-200 text-center">
         <div className="hero flex flex-col divide-y-4 gap-4 bg-base-100 shadow-lg p-10 rounded-lg">
           <h1 className="text-5xl font-bold">Welcome to Running Journal</h1>
@@ -65,7 +59,12 @@ const WelcomePage = () => {
         <Outlet />
       </div>
       <Footer />
-    </>
+      <ToastContainer
+        position="bottom-right"
+        autoClose={2500}
+        theme="colored"
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
A complete revision in the way the calendar is build up. Each Schedule/Run pair form a single grid item. They are still tightly coupled as before, but as long as I stick to the current calendar model this is simply the way it is supposed to be. After the model has been revisioned this coupling can be loosened up so that in the end multiple schedule-/run-items can be dispalyed for EACH day.

Furthermore: the UI is now much more compact. Responsiveness added for all calendar items plus NavBar. Weeks are still one row, no matter how small the screen is, and I do not see a reasonable solution as simply setting the columns to ONE for very small screens is not in the original idea of the app to provide a great overview over one's training.